### PR TITLE
feat(image): make Nginx TCP port configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN ./build-index-files.sh
 FROM nginx:stable-alpine
 
 RUN rm /etc/nginx/conf.d/*
-COPY index.conf /etc/nginx/conf.d/
+COPY index.conf /etc/nginx/templates/index.conf.template
 
 COPY --from=build /work/out/* /usr/share/nginx/html/
+ENV NGINX_PORT=80

--- a/index.conf
+++ b/index.conf
@@ -1,6 +1,6 @@
 server {
-    listen 80;
-    listen [::]:80;
+    listen ${NGINX_PORT};
+    listen [::]:${NGINX_PORT};
 
     gzip on;
     gzip_types *;


### PR DESCRIPTION
This adds possibility to listen different TCP ports using `NGINX_PORT` environment variable. This is useful if you want to run multiple instances of this container inside one pod, e.g.:
```yaml
spec:
  containers:
    - image: ghcr.io/upcloudltd/hello
      name: hello80
      env:
        - name: NGINX_PORT
          value: "80"
    - image: ghcr.io/upcloudltd/hello
      name: hello8080
      env:
        - name: NGINX_PORT
          value: "8080"
    - image: ghcr.io/upcloudltd/hello
      name: hello81
      env:
        - name: NGINX_PORT
          value: "81"
```

`NGINX_PORT` defaults to `80` 